### PR TITLE
Fix problems with packaging in gazebo11

### DIFF
--- a/bionic/debian/changelog
+++ b/bionic/debian/changelog
@@ -1,3 +1,9 @@
+gazebo11 (11.0.0~pre1-2~bionic) bionic; urgency=medium
+
+  * gazebo11 11.0.0~pre1-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 27 Jan 2020 18:26:43 +0100
+
 gazebo11 (11.0.0~pre1-1~bionic) bionic; urgency=medium
 
   * gazebo11 11.0.0~pre1-1 release

--- a/debian/sid/debian/changelog
+++ b/debian/sid/debian/changelog
@@ -1,3 +1,9 @@
+gazebo11 (11.0.0~pre1-2~sid) sid; urgency=medium
+
+  * gazebo11 11.0.0~pre1-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 27 Jan 2020 18:26:44 +0100
+
 gazebo11 (11.0.0~pre1-1~sid) sid; urgency=medium
 
   * gazebo11 11.0.0~pre1-1 release

--- a/debian/stretch/debian/changelog
+++ b/debian/stretch/debian/changelog
@@ -1,3 +1,9 @@
+gazebo11 (11.0.0~pre1-2~stretch) stretch; urgency=medium
+
+  * gazebo11 11.0.0~pre1-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 27 Jan 2020 18:26:44 +0100
+
 gazebo11 (11.0.0~pre1-1~stretch) stretch; urgency=medium
 
   * gazebo11 11.0.0~pre1-1 release

--- a/ubuntu/debian/gazebo-plugin-base.install
+++ b/ubuntu/debian/gazebo-plugin-base.install
@@ -1,1 +1,2 @@
 usr/lib/*/gazebo-*/plugins/*.so
+usr/lib/*/gazebo-*/plugins/*.a

--- a/ubuntu/debian/gazebo.install
+++ b/ubuntu/debian/gazebo.install
@@ -2,3 +2,4 @@ usr/bin/gz*
 usr/bin/gazebo*
 usr/share/gazebo/*
 usr/share/gazebo-*/setup.sh
+usr/share/man/*


### PR DESCRIPTION
Problems with some files out of the packaging:

```
dh_missing: usr/lib/x86_64-linux-gnu/gazebo-11/plugins/libTrackedVehiclePlugin.a exists in debian/tmp but is not installed to anywhere
dh_missing: usr/share/man/man1/gzclient.1.gz exists in debian/tmp but is not installed to anywhere
dh_missing: usr/share/man/man1/gzprop.1.gz exists in debian/tmp but is not installed to anywhere
dh_missing: usr/share/man/man1/gzserver.1.gz exists in debian/tmp but is not installed to anywhere
dh_missing: usr/share/man/man1/gz.1.gz exists in debian/tmp but is not installed to anywhere
dh_missing: usr/share/man/man1/gazebo.1.gz exists in debian/tmp but is not installed to anywhere
```
Add man pages to gazebo11 package. Added static files to plugins.