### PR TITLE
Install setup.bash with setup.*sh rule

### DIFF
--- a/ubuntu/debian/gazebo.install
+++ b/ubuntu/debian/gazebo.install
@@ -1,5 +1,5 @@
 usr/bin/gz*
 usr/bin/gazebo*
 usr/share/gazebo/*
-usr/share/gazebo-*/setup.sh
+usr/share/gazebo-*/setup.*sh
 usr/share/man/*


### PR DESCRIPTION
We need to update the install rules to include `setup.bash` since https://github.com/osrf/gazebo/pull/3061 was merged.

~~~
dh_missing: usr/share/gazebo-11/setup.bash exists in debian/tmp but is not installed to anywhere
~~~

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo11-debbuilder&build=106)](https://build.osrfoundation.org/job/gazebo11-debbuilder/106/) https://build.osrfoundation.org/job/gazebo11-debbuilder/106/

Testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo11-debbuilder&build=110)](https://build.osrfoundation.org/job/gazebo11-debbuilder/110/) https://build.osrfoundation.org/job/gazebo11-debbuilder/110/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo11-debbuilder&build=111)](https://build.osrfoundation.org/job/gazebo11-debbuilder/111/) https://build.osrfoundation.org/job/gazebo11-debbuilder/111/