### PR TITLE
Relax the -common dependency to avoid releasing problems (buster)

### DIFF
--- a/debian/buster/debian/control
+++ b/debian/buster/debian/control
@@ -89,7 +89,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libgazebo11 (= ${binary:Version}),
-         gazebo11-common (= ${source:Version})
+         gazebo11-common (>= 11.2.0)
 Recommends: gazebo11-plugin-base
 Suggests: gazebo11-doc
 Multi-Arch: foreign
@@ -165,7 +165,7 @@ Depends: libtbb-dev,
          libsimbody-dev (<< 4.0.0),
          libbullet-dev,
          libgazebo11 (= ${binary:Version}),
-         gazebo11-common (= ${source:Version}),
+         gazebo11-common (>= 11.2.0),
          gazebo11-plugin-base (= ${source:Version}),
          ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
Follow up https://github.com/ignition-release/gazebo11-release/pull/6#issuecomment-901206803
